### PR TITLE
TLDR-260 fix docx bug: change attachment annotation value

### DIFF
--- a/dedoc/readers/docx_reader/data_structures/docx_document.py
+++ b/dedoc/readers/docx_reader/data_structures/docx_document.py
@@ -70,7 +70,7 @@ class DocxDocument:
                 continue
 
             if paragraph_xml.pict:  # diagrams are saved using docx_attachments_extractor
-                self.__handle_diagrams_xml(paragraph_xml, diagram_refs, uids_set, cnt)
+                self.__handle_diagram_xml(paragraph_xml, diagram_refs, uids_set, cnt)
                 continue
 
             if paragraph_xml.name != 'p':
@@ -187,10 +187,10 @@ class DocxDocument:
                 image_uid = self.attachment_name2uid[image_name]
             else:
                 self.logger.info(f"Attachment with name {image_name} not found")
-                return
+                continue
             image_refs[len(self.paragraph_list) - 1].append(image_uid)
 
-    def __handle_diagrams_xml(self, xml: Tag, diagram_refs: dict, uids_set: set, cnt: Counter) -> None:
+    def __handle_diagram_xml(self, xml: Tag, diagram_refs: dict, uids_set: set, cnt: Counter) -> None:
         diagram_name = f"{hashlib.md5(xml.encode()).hexdigest()}.docx"
         if diagram_name in self.attachment_name2uid:
             diagram_uid = self.attachment_name2uid[diagram_name]

--- a/dedoc/readers/docx_reader/data_structures/docx_document.py
+++ b/dedoc/readers/docx_reader/data_structures/docx_document.py
@@ -9,6 +9,7 @@ from typing import Optional, List
 from bs4 import BeautifulSoup, Tag
 
 from dedoc.common.exceptions.bad_file_exception import BadFileFormatException
+from dedoc.data_structures.attached_file import AttachedFile
 from dedoc.data_structures.concrete_annotations.attach_annotation import AttachAnnotation
 from dedoc.data_structures.concrete_annotations.table_annotation import TableAnnotation
 from dedoc.data_structures.line_with_meta import LineWithMeta
@@ -23,10 +24,11 @@ from dedoc.utils.utils import calculate_file_hash
 
 
 class DocxDocument:
-    def __init__(self, path: str, logger: logging.Logger) -> None:
+    def __init__(self, path: str, attachments: List[AttachedFile], logger: logging.Logger) -> None:
         self.logger = logger
         self.path = path
         self.path_hash = calculate_file_hash(path=path)
+        self.attachment_name2uid = {attachment.original_name: attachment.uid for attachment in attachments}
 
         self.document_bs_tree = self.__get_bs_tree('word/document.xml')
         if self.document_bs_tree is None:
@@ -179,11 +181,22 @@ class DocxDocument:
 
         for image_xml in xmls:
             blips = image_xml.find_all("a:blip")
-            image_uid = images_rels[blips[0]["r:embed"]]
+            image_name = images_rels[blips[0]["r:embed"]]
+
+            if image_name in self.attachment_name2uid:
+                image_uid = self.attachment_name2uid[image_name]
+            else:
+                self.logger.info(f"Attachment with name {image_name} not found")
+                return
             image_refs[len(self.paragraph_list) - 1].append(image_uid)
 
     def __handle_diagrams_xml(self, xml: Tag, diagram_refs: dict, uids_set: set, cnt: Counter) -> None:
-        diagram_uid = hashlib.md5(xml.encode()).hexdigest()
+        diagram_name = f"{hashlib.md5(xml.encode()).hexdigest()}.docx"
+        if diagram_name in self.attachment_name2uid:
+            diagram_uid = self.attachment_name2uid[diagram_name]
+        else:
+            self.logger.info(f"Attachment with name {diagram_name} not found")
+            return
         self.__prepare_paragraph_list(uids_set, cnt)
         diagram_refs[len(self.paragraph_list) - 1].append(diagram_uid)
 

--- a/dedoc/readers/docx_reader/docx_reader.py
+++ b/dedoc/readers/docx_reader/docx_reader.py
@@ -3,12 +3,12 @@ import os
 from typing import Optional, List
 
 from dedoc.attachments_extractors.concrete_attachments_extractors.docx_attachments_extractor import DocxAttachmentsExtractor
+from dedoc.data_structures.hierarchy_level import HierarchyLevel
 from dedoc.data_structures.line_with_meta import LineWithMeta
 from dedoc.data_structures.unstructured_document import UnstructuredDocument
 from dedoc.extensions import recognized_extensions, recognized_mimes
 from dedoc.readers.base_reader import BaseReader
 from dedoc.readers.docx_reader.data_structures.docx_document import DocxDocument
-from dedoc.data_structures.hierarchy_level import HierarchyLevel
 
 
 class DocxReader(BaseReader):
@@ -34,8 +34,9 @@ class DocxReader(BaseReader):
         Look to the documentation of :meth:`~dedoc.readers.BaseReader.read` to get information about the method's parameters.
         """
         parameters = {} if parameters is None else parameters
-        docx_document = self._parse_document(path=path)
         attachments = self.attachment_extractor.get_attachments(tmpdir=os.path.dirname(path), filename=os.path.basename(path), parameters=parameters)
+
+        docx_document = DocxDocument(path=path, attachments=attachments, logger=self.logger)
         lines = self.__fix_lines(docx_document.lines)
         return UnstructuredDocument(lines=lines, tables=docx_document.tables, attachments=attachments, warnings=[])
 
@@ -54,7 +55,3 @@ class DocxReader(BaseReader):
                     annotation.end += 1
 
         return lines
-
-    def _parse_document(self, path: str) -> DocxDocument:
-        docx_document = DocxDocument(path=path, logger=self.logger)
-        return docx_document

--- a/dedoc/train_dataset/taskers/images_creators/concrete_creators/docx_images_creator.py
+++ b/dedoc/train_dataset/taskers/images_creators/concrete_creators/docx_images_creator.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 from copy import deepcopy
 from typing import Iterator, Optional, Dict, Iterable, Tuple
 from typing import List
+
 import numpy as np
 from PIL import Image
 from PIL import ImageColor
@@ -18,11 +19,9 @@ from pdf2image import convert_from_path
 from dedoc.common.exceptions.conversion_exception import ConversionException
 from dedoc.readers.docx_reader.data_structures.docx_document import DocxDocument
 from dedoc.readers.docx_reader.data_structures.paragraph import Paragraph
-from dedoc.readers.docx_reader.docx_reader import DocxReader
 from dedoc.readers.pdf_reader.pdf_image_reader.pdf_image_reader import PdfImageReader
-from dedoc.train_dataset.train_dataset_utils import get_original_document_path
-
 from dedoc.train_dataset.taskers.images_creators.concrete_creators.abstract_images_creator import AbstractImagesCreator
+from dedoc.train_dataset.train_dataset_utils import get_original_document_path
 from dedoc.utils.image_utils import get_concat_v
 
 PairedPdf = namedtuple("PairedPdf", ["many_color_pdf", "two_color_pdf", "many_colors", "two_colors"])
@@ -32,7 +31,6 @@ class DocxImagesCreator(AbstractImagesCreator):
 
     def __init__(self, path2docs: str, *, config: dict) -> None:
         self.path2docs = path2docs
-        self.docx_reader = DocxReader(config=config)
         self.color_step = 16
         self.first_color = 15
         self.base_color = 0
@@ -58,7 +56,7 @@ class DocxImagesCreator(AbstractImagesCreator):
         """
         path2doc = get_original_document_path(self.path2docs, page)
         # here we get half processing docx document (with raw xml)
-        document = self.docx_reader._parse_document(path2doc)
+        document = DocxDocument(path=path2doc, attachments=[], logger=self.logger)
         with zipfile.ZipFile(path2doc) as d:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 pdfs = self.__create_pair_pdfs(docx_archive=d, document=document, tmp_dir=tmp_dir)

--- a/tests/api_tests/test_api_with_images_refs.py
+++ b/tests/api_tests/test_api_with_images_refs.py
@@ -10,52 +10,55 @@ class TestApiImageRefs(AbstractTestApiDocReader):
     def test_docx_with_images(self) -> None:
         file_name = "docx_with_images.docx"
         result = self._send_request(file_name, dict(with_attachments=True, structure_type="linear"))
+        attachments_name2uid = {attachment["metadata"]["file_name"]: attachment["metadata"]["uid"] for attachment in result["attachments"]}
         content = result["content"]["structure"]
 
         image_paragraph = content["subparagraphs"][0]
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image1.png')
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image1.png'])
 
         image_paragraph = content["subparagraphs"][2]
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image2.jpeg')
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image3.jpeg')
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image2.jpeg'])
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image3.jpeg'])
 
         image_paragraph = content["subparagraphs"][5]
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image4.jpeg')
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image4.jpeg'])
 
         image_paragraph = content["subparagraphs"][6]
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image5.jpeg')
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image6.jpeg')
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image7.jpeg')
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image5.jpeg'])
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image6.jpeg'])
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image7.jpeg'])
 
     def test_odt_with_images(self) -> None:
         file_name = "odt_with_images.odt"
         result = self._send_request(file_name, dict(with_attachments=True, structure_type="linear"))
+        attachments_name2uid = {attachment["metadata"]["file_name"]: attachment["metadata"]["uid"] for attachment in result["attachments"]}
         content = result["content"]["structure"]
 
         image_paragraph = content["subparagraphs"][0]
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image1.jpeg')
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image1.jpeg'])
 
         image_paragraph = content["subparagraphs"][7]
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image2.jpeg')
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image2.jpeg'])
 
         image_paragraph = content["subparagraphs"][8]
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image3.jpeg')
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image3.jpeg'])
 
     def test_docx_with_images_from_mac(self) -> None:
         file_name = "doc_with_images.docx"
         result = self._send_request(file_name, dict(with_attachments=True, structure_type="linear"))
+        attachments_name2uid = {attachment["metadata"]["file_name"]: attachment["metadata"]["uid"] for attachment in result["attachments"]}
         content = result["content"]["structure"]
 
         image_paragraph = content["subparagraphs"][2]
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image1.jpeg')
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image1.jpeg'])
 
         image_paragraph = content["subparagraphs"][3]
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image2.jpeg')
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image2.jpeg'])
 
         image_paragraph = content["subparagraphs"][5]
-        self.__check_image_paragraph(image_paragraph=image_paragraph, image_name='image3.png')
+        self.__check_image_paragraph(image_paragraph=image_paragraph, image_uid=attachments_name2uid['image3.png'])
 
-    def __check_image_paragraph(self, image_paragraph: dict, image_name: str) -> None:
+    def __check_image_paragraph(self, image_paragraph: dict, image_uid: str) -> None:
         text = image_paragraph["text"]
         image_annotations = image_paragraph["annotations"]
-        self.assertIn({'start': 0, 'end': len(text), 'name': 'attachment', 'value': image_name}, image_annotations)
+        self.assertIn({'start': 0, 'end': len(text), 'name': 'attachment', 'value': image_uid}, image_annotations)


### PR DESCRIPTION
In docx the `value` attribute for `AttachAnnotation` contained file name instead of annotation uid. File names are unique for docx attachments (in docx intermediate representation), so the annotations values are replaced using dictionary {file name: attachment uid}