### PR TITLE
TLDR-549 delete custom loggers

### DIFF
--- a/dedoc/readers/pdf_reader/data_classes/tables/table_tree.py
+++ b/dedoc/readers/pdf_reader/data_classes/tables/table_tree.py
@@ -10,8 +10,6 @@ from dedoc.data_structures import LineWithMeta
 from dedoc.readers.pdf_reader.pdf_image_reader.ocr.ocr_cell_extractor import OCRCellExtractor
 from dedoc.utils.image_utils import crop_image_text
 
-logger = logging.getLogger("TableRecognizer.TableTree")
-
 """-------------------------------Таблица в виде дерева, полученная от OpenCV----------------------------------------"""
 ContourCell = namedtuple("ContourCell", ["id_con", "image"])
 

--- a/dedoc/readers/pdf_reader/pdf_image_reader/table_recognizer/table_recognizer.py
+++ b/dedoc/readers/pdf_reader/pdf_image_reader/table_recognizer/table_recognizer.py
@@ -22,7 +22,7 @@ class TableRecognizer(object):
 
     def __init__(self, *, config: dict = None) -> None:
 
-        self.logger = config.get("logger", logging.getLogger(__name__))
+        self.logger = config.get("logger", logging.getLogger())
 
         self.onepage_tables_extractor = OnePageTableExtractor(config=config, logger=self.logger)
         self.multipage_tables_extractor = MultiPageTableExtractor(config=config, logger=self.logger)

--- a/dedoc/readers/pdf_reader/pdf_image_reader/table_recognizer/table_utils/img_processing.py
+++ b/dedoc/readers/pdf_reader/pdf_image_reader/table_recognizer/table_utils/img_processing.py
@@ -13,7 +13,6 @@ from dedoc.readers.pdf_reader.data_classes.tables.table_type import TableTypeAdd
 from dedoc.utils.parameter_utils import get_path_param
 
 logger = get_config().get("logger", logging.getLogger())
-logger = logger if logger else logging.getLogger("TableRecognizer.detect_tables_by_contours")
 table_options = TableTypeAdditionalOptions()
 
 ROTATE_THRESHOLD = 0.3

--- a/dedoc/readers/pdf_reader/pdf_txtlayer_reader/pdfminer_reader/pdfminer_extractor.py
+++ b/dedoc/readers/pdf_reader/pdf_txtlayer_reader/pdfminer_reader/pdfminer_extractor.py
@@ -31,6 +31,7 @@ from dedoc.readers.pdf_reader.pdf_txtlayer_reader.pdfminer_reader.pdfminer_utils
 from dedoc.utils.parameter_utils import get_path_param
 from dedoc.utils.pdf_utils import get_page_image
 
+logging.getLogger("pdfminer").setLevel(logging.ERROR)
 WordObj = namedtuple("Word", ["start", "end", "value"])
 
 

--- a/dedoc/readers/pdf_reader/pdf_txtlayer_reader/pdfminer_reader/pdfminer_extractor.py
+++ b/dedoc/readers/pdf_reader/pdf_txtlayer_reader/pdfminer_reader/pdfminer_extractor.py
@@ -31,7 +31,6 @@ from dedoc.readers.pdf_reader.pdf_txtlayer_reader.pdfminer_reader.pdfminer_utils
 from dedoc.utils.parameter_utils import get_path_param
 from dedoc.utils.pdf_utils import get_page_image
 
-logging.getLogger("pdfminer").setLevel(logging.ERROR)
 WordObj = namedtuple("Word", ["start", "end", "value"])
 
 


### PR DESCRIPTION
https://jira.intra.ispras.ru/browse/TLDR-549

удалил все кастомные логгеры, во всех остальных случаях используется конструкция `logger = config.get("logger", logging.getLogger())`