### PR TITLE
TLDR-688 deleted noqa

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,8 @@ inline-quotes = "
 application-import-names = dedoc, tests, scripts, train_dataset
 import-order-style = pycharm
 
+extend-immutable-calls = File, Depends
+
 exclude =
     .git,
     __pycache__,

--- a/.github/check_version.py
+++ b/.github/check_version.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     print(f"Old version: {args.old_version}, new version: {args.new_version}, "
-          f"branch: {args.branch}, tag: {args.tag}, pre_release: {args.pre_release}")  # noqa
+          f"branch: {args.branch}, tag: {args.tag}, pre_release: {args.pre_release}")
 
     master_version_pattern = re.compile(r"^\d+\.\d+(\.\d+)?$")
     develop_version_pattern = re.compile(r"^\d+\.\d+\.\d+rc\d+$")
@@ -43,4 +43,4 @@ if __name__ == "__main__":
         is_correct_version(args.new_version, args.tag, args.old_version, master_version_pattern)
         assert args.pre_release != "true", "Pre-releases are not allowed on master"
 
-    print("Version is correct")  # noqa
+    print("Version is correct")

--- a/dedoc/__init__.py
+++ b/dedoc/__init__.py
@@ -1,2 +1,2 @@
-from .dedoc_manager import DedocManager  # noqa
-from .version import __version__  # noqa
+from .dedoc_manager import DedocManager
+from .version import __version__

--- a/dedoc/api/dedoc_api.py
+++ b/dedoc/api/dedoc_api.py
@@ -70,7 +70,7 @@ def __add_base64_info_to_attachments(document_tree: ParsedDocument, attachments_
 
 
 @app.post("/upload", response_model=ParsedDocument)
-async def upload(file: UploadFile = File(...), query_params: QueryParameters = Depends()) -> Response:  # noqa
+async def upload(file: UploadFile = File(...), query_params: QueryParameters = Depends()) -> Response:
     parameters = dataclasses.asdict(query_params)
     if not file or file.filename == "":
         raise MissingFileError("Error: Missing content in request_post file parameter", version=dedoc.__version__)

--- a/dedoc/attachments_handler/attachments_handler.py
+++ b/dedoc/attachments_handler/attachments_handler.py
@@ -4,6 +4,7 @@ import os
 import time
 from typing import List, Optional
 
+from dedoc import DedocManager
 from dedoc.common.exceptions.dedoc_error import DedocError
 from dedoc.data_structures import AttachedFile, DocumentMetadata, ParsedDocument
 from dedoc.data_structures.unstructured_document import UnstructuredDocument
@@ -29,7 +30,7 @@ class AttachmentsHandler:
         self.config = {} if config is None else config
         self.logger = self.config.get("logger", logging.getLogger())
 
-    def handle_attachments(self, document_parser: "DedocManager", document: UnstructuredDocument, parameters: dict) -> List[ParsedDocument]:  # noqa
+    def handle_attachments(self, document_parser: "DedocManager", document: UnstructuredDocument, parameters: dict) -> List[ParsedDocument]:
         """
         Handle attachments of the document in the intermediate representation.
 
@@ -76,7 +77,7 @@ class AttachmentsHandler:
             attachments.append(parsed_file)
         return attachments
 
-    def __get_empty_document(self, document_parser: "DedocManager", attachment: AttachedFile, parameters: dict) -> ParsedDocument:  # noqa
+    def __get_empty_document(self, document_parser: "DedocManager", attachment: AttachedFile, parameters: dict) -> ParsedDocument:
         metadata = document_parser.document_metadata_extractor.extract(
             file_path=attachment.get_filename_in_path(),
             original_filename=attachment.get_original_filename(),

--- a/dedoc/attachments_handler/attachments_handler.py
+++ b/dedoc/attachments_handler/attachments_handler.py
@@ -30,7 +30,7 @@ class AttachmentsHandler:
         self.config = {} if config is None else config
         self.logger = self.config.get("logger", logging.getLogger())
 
-    def handle_attachments(self, document_parser: "DedocManager", document: UnstructuredDocument, parameters: dict) -> List[ParsedDocument]:
+    def handle_attachments(self, document_parser: DedocManager, document: UnstructuredDocument, parameters: dict) -> List[ParsedDocument]:
         """
         Handle attachments of the document in the intermediate representation.
 
@@ -77,7 +77,7 @@ class AttachmentsHandler:
             attachments.append(parsed_file)
         return attachments
 
-    def __get_empty_document(self, document_parser: "DedocManager", attachment: AttachedFile, parameters: dict) -> ParsedDocument:
+    def __get_empty_document(self, document_parser: DedocManager, attachment: AttachedFile, parameters: dict) -> ParsedDocument:
         metadata = document_parser.document_metadata_extractor.extract(
             file_path=attachment.get_filename_in_path(),
             original_filename=attachment.get_original_filename(),

--- a/dedoc/data_structures/cell_with_meta.py
+++ b/dedoc/data_structures/cell_with_meta.py
@@ -40,7 +40,7 @@ class CellWithMeta(Serializable):
         return LineWithMeta.join(lines=self.lines, delimiter="\n").annotations
 
     @staticmethod
-    def create_from_cell(cell: "Cell") -> "CellWithMeta": # noqa
+    def create_from_cell(cell: "CellWithMeta") -> "CellWithMeta":
         return CellWithMeta(lines=cell.lines, colspan=cell.colspan, rowspan=cell.rowspan, invisible=cell.invisible)
 
     def to_api_schema(self) -> ApiCellWithMeta:

--- a/dedoc/data_structures/document_metadata.py
+++ b/dedoc/data_structures/document_metadata.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, Dict, Union
+from typing import Dict, Union
 
 from dedoc.api.schema.document_metadata import DocumentMetadata as ApiDocumentMetadata
 from dedoc.data_structures.serializable import Serializable
@@ -41,7 +41,7 @@ class DocumentMetadata(Serializable):
             self.add_attribute(key, value)
         self.uid = f"doc_uid_auto_{uuid.uuid1()}" if uid is None else uid
 
-    def add_attribute(self, key: str, value: Any) -> None:  # noqa
+    def add_attribute(self, key: str, value: Union[str, int, float]) -> None:
         setattr(self, key, value)
 
     def to_api_schema(self) -> ApiDocumentMetadata:

--- a/dedoc/main.py
+++ b/dedoc/main.py
@@ -1,4 +1,4 @@
-from dedoc.api.dedoc_api import get_api, run_api  # noqa
+from dedoc.api.dedoc_api import get_api, run_api
 from dedoc.config import Configuration
 
 

--- a/dedoc/metadata_extractors/concrete_metadata_extractors/image_metadata_extractor.py
+++ b/dedoc/metadata_extractors/concrete_metadata_extractors/image_metadata_extractor.py
@@ -109,6 +109,6 @@ class ImageMetadataExtractor(AbstractMetadataExtractor):
             encoded_dict = {k: v for k, v in encoded_dict.items() if k is not None if v is not None}
             image.close()
             return encoded_dict
-        except Exception as e:  # noqa
+        except Exception as e:
             self.logger.debug(e)
             return {"broken_image": True}

--- a/dedoc/metadata_extractors/concrete_metadata_extractors/pdf_metadata_extractor.py
+++ b/dedoc/metadata_extractors/concrete_metadata_extractors/pdf_metadata_extractor.py
@@ -84,7 +84,7 @@ class PdfMetadataExtractor(AbstractMetadataExtractor):
                 elif key in self.keys_date:
                     try:
                         date = convert_datetime(value)
-                    except:  # noqa
+                    except Exception:
                         date = None
                     if date is not None:
                         result[self.keys_date[key]] = date

--- a/dedoc/readers/docx_reader/data_structures/base_props.py
+++ b/dedoc/readers/docx_reader/data_structures/base_props.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 class BaseProperties:
 
-    def __init__(self, properties: Optional["BaseProperties"] = None) -> None:  # noqa
+    def __init__(self, properties: Optional["BaseProperties"] = None) -> None:
         """
         Contains style properties for paragraphs and runs.
         :param properties: Paragraph or Run for copying its properties

--- a/dedoc/readers/docx_reader/data_structures/run.py
+++ b/dedoc/readers/docx_reader/data_structures/run.py
@@ -8,7 +8,7 @@ from dedoc.readers.docx_reader.properties_extractor import change_caps
 
 class Run(BaseProperties):
 
-    def __init__(self, properties: Optional["BaseProperties"], styles_extractor: "StylesExtractor") -> None:  # noqa
+    def __init__(self, properties: Optional[BaseProperties], styles_extractor: "StylesExtractor") -> None:  # noqa
         """
         Contains information about run properties.
         :param properties: Paragraph or Run for copying its properties

--- a/dedoc/readers/docx_reader/data_structures/run.py
+++ b/dedoc/readers/docx_reader/data_structures/run.py
@@ -4,11 +4,12 @@ from bs4 import Tag
 
 from dedoc.readers.docx_reader.data_structures.base_props import BaseProperties
 from dedoc.readers.docx_reader.properties_extractor import change_caps
+from dedoc.readers.docx_reader.styles_extractor import StylesExtractor
 
 
 class Run(BaseProperties):
 
-    def __init__(self, properties: Optional[BaseProperties], styles_extractor: "StylesExtractor") -> None:  # noqa
+    def __init__(self, properties: Optional["BaseProperties"], styles_extractor: "StylesExtractor") -> None:
         """
         Contains information about run properties.
         :param properties: Paragraph or Run for copying its properties

--- a/dedoc/readers/docx_reader/data_structures/run.py
+++ b/dedoc/readers/docx_reader/data_structures/run.py
@@ -4,12 +4,11 @@ from bs4 import Tag
 
 from dedoc.readers.docx_reader.data_structures.base_props import BaseProperties
 from dedoc.readers.docx_reader.properties_extractor import change_caps
-from dedoc.readers.docx_reader.styles_extractor import StylesExtractor
 
 
 class Run(BaseProperties):
 
-    def __init__(self, properties: Optional["BaseProperties"], styles_extractor: "StylesExtractor") -> None:
+    def __init__(self, properties: Optional["BaseProperties"], styles_extractor: "StylesExtractor") -> None:  # noqa
         """
         Contains information about run properties.
         :param properties: Paragraph or Run for copying its properties

--- a/dedoc/readers/pdf_reader/pdf_base_reader.py
+++ b/dedoc/readers/pdf_reader/pdf_base_reader.py
@@ -179,7 +179,7 @@ class PdfBaseReader(BaseReader):
             while (images is None or len(images) > 0) and left <= min(page_to, page_count):
                 right = left + step
                 # for convert_from_path function first_page should start from 1, last_page is included to the result
-                images = convert_from_path(path, first_page=left, last_page=right)  # noqa
+                images = convert_from_path(path, first_page=left, last_page=right)
                 # in logging we include both ends of the pages interval, numeration starts with 1
                 self.logger.info(f"Get page from {left} to {min(right, page_count)} of {page_count} file {os.path.basename(path)}")
                 for image in images:

--- a/dedoc/readers/pdf_reader/pdf_image_reader/ocr/ocr_cell_extractor.py
+++ b/dedoc/readers/pdf_reader/pdf_image_reader/ocr/ocr_cell_extractor.py
@@ -7,6 +7,7 @@ import numpy as np
 from dedocutils.data_structures import BBox
 
 from dedoc.data_structures import BBoxAnnotation, ConfidenceAnnotation, LineMetadata, LineWithMeta
+from dedoc.readers.pdf_reader.data_classes.tables.table_tree import TableTree
 from dedoc.readers.pdf_reader.pdf_image_reader.ocr.ocr_line_extractor import OCRLineExtractor
 from dedoc.readers.pdf_reader.pdf_image_reader.ocr.ocr_page.ocr_page import OcrPage
 from dedoc.readers.pdf_reader.pdf_image_reader.ocr.ocr_utils import get_text_with_bbox_from_cells
@@ -21,7 +22,7 @@ class OCRCellExtractor:
         self.line_extractor = OCRLineExtractor(config=config)
         self.logger = config.get("logger", logging.getLogger())
 
-    def get_cells_text(self, page_image: np.ndarray, tree_nodes: List["TableTree"], language: str) -> List[List[LineWithMeta]]:  # noqa
+    def get_cells_text(self, page_image: np.ndarray, tree_nodes: List["TableTree"], language: str) -> List[List[LineWithMeta]]:
         for node in tree_nodes:
             node.set_crop_text_box(page_image)
 
@@ -62,7 +63,8 @@ class OCRCellExtractor:
 
         return self.__create_lines_with_meta(tree_nodes, originalbox_to_fastocrbox, page_image)
 
-    def __handle_one_batch(self, src_image: np.ndarray, tree_table_nodes: List["TableTree"], num_batch: int, language: str = "rus") -> Tuple[OcrPage, List[BBox]]: # noqa
+    def __handle_one_batch(self, src_image: np.ndarray, tree_table_nodes: List["TableTree"], num_batch: int, language: str = "rus") \
+            -> Tuple[OcrPage, List[BBox]]:
         concatenated, chunk_boxes = self.__concat_images(src_image=src_image, tree_table_nodes=tree_table_nodes)
         if self.config.get("debug_mode", False):
             debug_dir = os.path.join(get_path_param(self.config, "path_debug"), "debug_tables", "batches")
@@ -73,7 +75,7 @@ class OCRCellExtractor:
 
         return ocr_result, chunk_boxes
 
-    def __concat_images(self, src_image: np.ndarray, tree_table_nodes: List["TableTree"]) -> Tuple[np.ndarray, List[BBox]]:  # noqa
+    def __concat_images(self, src_image: np.ndarray, tree_table_nodes: List["TableTree"]) -> Tuple[np.ndarray, List[BBox]]:
         space = 10
         width = max((tree_node.crop_text_box.width + space for tree_node in tree_table_nodes))
         height = sum((tree_node.crop_text_box.height + space for tree_node in tree_table_nodes))
@@ -103,7 +105,7 @@ class OCRCellExtractor:
         assert len(chunk_boxes) == len(tree_table_nodes)
         return stacked_image, chunk_boxes
 
-    def __nodes2batch(self, tree_nodes: List["TableTree"]) -> Iterator[List["TableTree"]]:  # noqa
+    def __nodes2batch(self, tree_nodes: List["TableTree"]) -> Iterator[List["TableTree"]]:
         batch = []
         width = 0
         height = 0
@@ -120,7 +122,8 @@ class OCRCellExtractor:
         if len(batch) > 0:
             yield batch
 
-    def __create_lines_with_meta(self, tree_nodes: List["TableTree"], original_box_to_fast_ocr_box: dict, original_image: np.ndarray) -> List[List[LineWithMeta]]:  # noqa
+    def __create_lines_with_meta(self, tree_nodes: List["TableTree"], original_box_to_fast_ocr_box: dict, original_image: np.ndarray) \
+            -> List[List[LineWithMeta]]:
         nodes_lines = []
 
         for node in tree_nodes:

--- a/dedoc/readers/pdf_reader/pdf_image_reader/ocr/ocr_cell_extractor.py
+++ b/dedoc/readers/pdf_reader/pdf_image_reader/ocr/ocr_cell_extractor.py
@@ -7,7 +7,6 @@ import numpy as np
 from dedocutils.data_structures import BBox
 
 from dedoc.data_structures import BBoxAnnotation, ConfidenceAnnotation, LineMetadata, LineWithMeta
-from dedoc.readers.pdf_reader.data_classes.tables.table_tree import TableTree
 from dedoc.readers.pdf_reader.pdf_image_reader.ocr.ocr_line_extractor import OCRLineExtractor
 from dedoc.readers.pdf_reader.pdf_image_reader.ocr.ocr_page.ocr_page import OcrPage
 from dedoc.readers.pdf_reader.pdf_image_reader.ocr.ocr_utils import get_text_with_bbox_from_cells
@@ -22,7 +21,7 @@ class OCRCellExtractor:
         self.line_extractor = OCRLineExtractor(config=config)
         self.logger = config.get("logger", logging.getLogger())
 
-    def get_cells_text(self, page_image: np.ndarray, tree_nodes: List["TableTree"], language: str) -> List[List[LineWithMeta]]:
+    def get_cells_text(self, page_image: np.ndarray, tree_nodes: List["TableTree"], language: str) -> List[List[LineWithMeta]]:  # noqa
         for node in tree_nodes:
             node.set_crop_text_box(page_image)
 
@@ -64,7 +63,7 @@ class OCRCellExtractor:
         return self.__create_lines_with_meta(tree_nodes, originalbox_to_fastocrbox, page_image)
 
     def __handle_one_batch(self, src_image: np.ndarray, tree_table_nodes: List["TableTree"], num_batch: int, language: str = "rus") \
-            -> Tuple[OcrPage, List[BBox]]:
+            -> Tuple[OcrPage, List[BBox]]:  # noqa
         concatenated, chunk_boxes = self.__concat_images(src_image=src_image, tree_table_nodes=tree_table_nodes)
         if self.config.get("debug_mode", False):
             debug_dir = os.path.join(get_path_param(self.config, "path_debug"), "debug_tables", "batches")
@@ -75,7 +74,7 @@ class OCRCellExtractor:
 
         return ocr_result, chunk_boxes
 
-    def __concat_images(self, src_image: np.ndarray, tree_table_nodes: List["TableTree"]) -> Tuple[np.ndarray, List[BBox]]:
+    def __concat_images(self, src_image: np.ndarray, tree_table_nodes: List["TableTree"]) -> Tuple[np.ndarray, List[BBox]]:  # noqa
         space = 10
         width = max((tree_node.crop_text_box.width + space for tree_node in tree_table_nodes))
         height = sum((tree_node.crop_text_box.height + space for tree_node in tree_table_nodes))
@@ -105,7 +104,7 @@ class OCRCellExtractor:
         assert len(chunk_boxes) == len(tree_table_nodes)
         return stacked_image, chunk_boxes
 
-    def __nodes2batch(self, tree_nodes: List["TableTree"]) -> Iterator[List["TableTree"]]:
+    def __nodes2batch(self, tree_nodes: List["TableTree"]) -> Iterator[List["TableTree"]]:  # noqa
         batch = []
         width = 0
         height = 0
@@ -123,7 +122,7 @@ class OCRCellExtractor:
             yield batch
 
     def __create_lines_with_meta(self, tree_nodes: List["TableTree"], original_box_to_fast_ocr_box: dict, original_image: np.ndarray) \
-            -> List[List[LineWithMeta]]:
+            -> List[List[LineWithMeta]]:  # noqa
         nodes_lines = []
 
         for node in tree_nodes:

--- a/dedoc/readers/pdf_reader/pdf_txtlayer_reader/pdfminer_reader/pdfminer_extractor.py
+++ b/dedoc/readers/pdf_reader/pdf_txtlayer_reader/pdfminer_reader/pdfminer_extractor.py
@@ -146,7 +146,7 @@ class PdfminerExtractor:
 
     @staticmethod
     def __get_image(path: str, page_num: int) -> np.ndarray:
-        image_page = np.array(get_page_image(path=path, page_id=page_num))  # noqa
+        image_page = np.array(get_page_image(path=path, page_id=page_num))
         image_page = np.array(image_page)
         if len(image_page.shape) == 2:
             image_page = cv2.cvtColor(image_page, cv2.COLOR_GRAY2BGR)

--- a/dedoc/readers/pdf_reader/utils/line_object_linker.py
+++ b/dedoc/readers/pdf_reader/utils/line_object_linker.py
@@ -57,7 +57,7 @@ class LineObjectLinker:
                 self.logger.warning(f"Unsupported page object type {page_object}")
                 if self.config.get("debug_mode", False):
                     raise Exception(f"Unsupported page object type {page_object}")
-            best_line.annotations.append(annotation)  # noqa
+            best_line.annotations.append(annotation)
         return lines
 
     def _add_lines(self, all_objects: List[Union[LineWithLocation, ScanTable, PdfImageAttachment]], lines_key: str, objects_with_line_candidate: dict) -> None:

--- a/dedoc/structure_constructors/concrete_structure_constructors/tree_constructor.py
+++ b/dedoc/structure_constructors/concrete_structure_constructors/tree_constructor.py
@@ -90,7 +90,7 @@ class TreeConstructor(AbstractStructureConstructor):
     def __create_list_line(line: LineWithMeta) -> LineWithMeta:
         hierarchy_level = HierarchyLevel(
             level_1=line.metadata.hierarchy_level.level_1,
-            level_2=line.metadata.hierarchy_level.level_2 - 0.5,  # noqa  it is intentionaly for lists
+            level_2=line.metadata.hierarchy_level.level_2 - 0.5,
             line_type="list",
             can_be_multiline=False
         )

--- a/dedoc/structure_extractors/feature_extractors/list_features/prefix/any_letter_prefix.py
+++ b/dedoc/structure_extractors/feature_extractors/list_features/prefix/any_letter_prefix.py
@@ -20,7 +20,7 @@ class AnyLetterPrefix(LinePrefix):
 
     regexp = re.compile(r"^\s*\w\)")
 
-    def predecessor(self, other: "LinePrefix") -> bool:
+    def predecessor(self, other: LinePrefix) -> bool:
         return isinstance(other, AnyLetterPrefix)
 
     @staticmethod

--- a/dedoc/structure_extractors/feature_extractors/list_features/prefix/bracket_prefix.py
+++ b/dedoc/structure_extractors/feature_extractors/list_features/prefix/bracket_prefix.py
@@ -18,7 +18,7 @@ class BracketPrefix(LinePrefix):
         super().__init__(prefix, indent=indent)
         self.prefix_num = int(self.prefix[:-1])
 
-    def predecessor(self, other: "LinePrefix") -> bool:
+    def predecessor(self, other: LinePrefix) -> bool:
         return isinstance(other, BracketPrefix) and self.prefix_num == other.prefix_num + 1
 
     @staticmethod

--- a/dedoc/structure_extractors/feature_extractors/list_features/prefix/bracket_roman_prefix.py
+++ b/dedoc/structure_extractors/feature_extractors/list_features/prefix/bracket_roman_prefix.py
@@ -22,7 +22,7 @@ class BracketRomanPrefix(LinePrefix):
         super().__init__(prefix, indent=indent)
         self.prefix_num = roman.fromRoman(self.prefix[:-1].upper().strip())
 
-    def predecessor(self, other: "LinePrefix") -> bool:
+    def predecessor(self, other: LinePrefix) -> bool:
         return isinstance(other, BracketRomanPrefix) and self.prefix_num == other.prefix_num + 1
 
     @staticmethod

--- a/dedoc/structure_extractors/feature_extractors/list_features/prefix/bullet_prefix.py
+++ b/dedoc/structure_extractors/feature_extractors/list_features/prefix/bullet_prefix.py
@@ -19,7 +19,7 @@ class BulletPrefix(LinePrefix):
 
     regexp = re.compile(r"^\s*(-|—|−|–|®|\.|•|\,|‚|©|⎯|°|\*|>|\| -|●|♣|①|▪|\*|\+)")
 
-    def predecessor(self, other: "LinePrefix") -> bool:
+    def predecessor(self, other: LinePrefix) -> bool:
         return isinstance(other, BulletPrefix) and self.prefix == other.prefix
 
     @staticmethod

--- a/dedoc/structure_extractors/feature_extractors/list_features/prefix/empty_prefix.py
+++ b/dedoc/structure_extractors/feature_extractors/list_features/prefix/empty_prefix.py
@@ -11,7 +11,7 @@ class EmptyPrefix(LinePrefix):
     def __init__(self, prefix: str = None, indent: float = 0) -> None:
         super().__init__("", indent=indent)
 
-    def predecessor(self, other: "LinePrefix") -> bool:
+    def predecessor(self, other: LinePrefix) -> bool:
         return False
 
     @staticmethod

--- a/dedoc/structure_extractors/feature_extractors/list_features/prefix/letter_prefix.py
+++ b/dedoc/structure_extractors/feature_extractors/list_features/prefix/letter_prefix.py
@@ -29,7 +29,7 @@ class LetterPrefix(LinePrefix):
         else:
             return ord(letter)
 
-    def predecessor(self, other: "LinePrefix") -> bool:
+    def predecessor(self, other: LinePrefix) -> bool:
         return isinstance(other, LetterPrefix) and 1 >= (self.order - other.order) > 0
 
     @staticmethod

--- a/dedoc/structure_extractors/feature_extractors/list_features/prefix/roman_prefix.py
+++ b/dedoc/structure_extractors/feature_extractors/list_features/prefix/roman_prefix.py
@@ -23,7 +23,7 @@ class RomanPrefix(LinePrefix):
         super().__init__(prefix, indent=indent)
         self.prefix_num = roman.fromRoman(self.prefix[:-1].upper().strip())
 
-    def predecessor(self, other: "LinePrefix") -> bool:
+    def predecessor(self, other: LinePrefix) -> bool:
         return isinstance(other, RomanPrefix) and self.prefix_num == other.prefix_num + 1
 
     @staticmethod

--- a/dedoc/structure_extractors/feature_extractors/paired_feature_extractor.py
+++ b/dedoc/structure_extractors/feature_extractors/paired_feature_extractor.py
@@ -54,7 +54,7 @@ class PairedFeatureExtractor(AbstractFeatureExtractor):
         stack = []
 
         for line in document:
-            while len(stack) > 0 and self.__compare_lines(stack[-1], line, get_feature, std) <= 0:  # noqa
+            while len(stack) > 0 and self.__compare_lines(stack[-1], line, get_feature, std) <= 0:
                 stack.pop()
             result.append(len(stack))
             stack.append(line)

--- a/dedoc/structure_extractors/line_type_classifiers/law_classifier.py
+++ b/dedoc/structure_extractors/line_type_classifiers/law_classifier.py
@@ -23,10 +23,10 @@ class LawLineTypeClassifier(AbstractPickledLineTypeClassifier):
             return []
 
         features = self.feature_extractor.transform([lines])
-        labels_probability = self.classifier.predict_proba(features)  # noqa
+        labels_probability = self.classifier.predict_proba(features)
 
         # mark lines inside quotes as raw_text
-        inside_quotes = np.array(LawTextFeatures()._inside_quotes(lines), dtype=bool)  # noqa
+        inside_quotes = np.array(LawTextFeatures()._inside_quotes(lines), dtype=bool)
         raw_text_id = list(self.classifier.classes_).index("raw_text")
         labels_probability[inside_quotes, raw_text_id] = 1
         labels = [self.classifier.classes_[label_id] for label_id in labels_probability.argmax(1)]

--- a/dedoc/utils/train_dataset_utils.py
+++ b/dedoc/utils/train_dataset_utils.py
@@ -6,6 +6,8 @@ import PIL
 import numpy as np
 from PIL.Image import Image
 
+from dedoc.data_structures import LineWithMeta
+
 
 def __to_pil(image: np.ndarray) -> Image:
     return PIL.Image.fromarray(image)
@@ -30,7 +32,7 @@ def _get_images_path(config: dict, document_name: str) -> str:
     return images_path
 
 
-def save_line_with_meta(lines: List["LineWithMeta"], original_document: str, *, config: dict) -> None:  # noqa
+def save_line_with_meta(lines: List["LineWithMeta"], original_document: str, *, config: dict) -> None:
     __create_images_path(config)
 
     # merge lines with the same bbox
@@ -45,7 +47,7 @@ def save_line_with_meta(lines: List["LineWithMeta"], original_document: str, *, 
             out.write("\n")
 
 
-def __postprocess_lines(lines: List["LineWithMeta"]) -> List["LineWithMeta"]:  # noqa
+def __postprocess_lines(lines: List["LineWithMeta"]) -> List["LineWithMeta"]:
     postprocessed_lines = []
     prev_bbox = None
     for line in lines:

--- a/dedoc/utils/train_dataset_utils.py
+++ b/dedoc/utils/train_dataset_utils.py
@@ -32,7 +32,7 @@ def _get_images_path(config: dict, document_name: str) -> str:
     return images_path
 
 
-def save_line_with_meta(lines: List["LineWithMeta"], original_document: str, *, config: dict) -> None:
+def save_line_with_meta(lines: List[LineWithMeta], original_document: str, *, config: dict) -> None:
     __create_images_path(config)
 
     # merge lines with the same bbox
@@ -47,7 +47,7 @@ def save_line_with_meta(lines: List["LineWithMeta"], original_document: str, *, 
             out.write("\n")
 
 
-def __postprocess_lines(lines: List["LineWithMeta"]) -> List["LineWithMeta"]:
+def __postprocess_lines(lines: List[LineWithMeta]) -> List[LineWithMeta]:
     postprocessed_lines = []
     prev_bbox = None
     for line in lines:

--- a/dedoc/utils/utils.py
+++ b/dedoc/utils/utils.py
@@ -209,7 +209,7 @@ def get_encoding(path: str, default: str = None) -> Optional[str]:
                 blob = file.read()
         dammit = from_bytes(blob)
         return dammit.best().encoding
-    except:  # noqa  ignore exception and return default encoding
+    except Exception:
         return default
 
 

--- a/labeling/train_dataset/api/api.py
+++ b/labeling/train_dataset/api/api.py
@@ -149,7 +149,7 @@ def handle_archive() -> Response:
 
 
 @app.post("/upload_archive")
-def upload_archive(file: UploadFile = File(...), query_params: TrainDatasetParameters = Depends()) -> Response:  # noqa
+def upload_archive(file: UploadFile = File(...), query_params: TrainDatasetParameters = Depends()) -> Response:
     """
     Run the whole pipeline of task making.
     """

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -80,9 +80,10 @@ with TemporaryDirectory() as path_base:
         Task("pdf_tables", "pdf_tables", {}, get_pdf_page_count)
     ]
     print(tasks)
-    header = ["Dataset", "total_file_size", "total_files", "total_pages", # noqa
-         "total_time_raw", "throughput_raw", "mean_time_on_file_raw", "mean_time_cpu_on_page_raw",  # noqa
-         "total_time_indp_cpu", "throughput_indp_cpu", "mean_time_on_file_indp_cpu", "mean_time_cpu_on_page_indp_cpu"]  # noqa
+    header = [
+        "Dataset", "total_file_size", "total_files", "total_pages", "total_time_raw", "throughput_raw", "mean_time_on_file_raw", "mean_time_cpu_on_page_raw",
+        "total_time_indp_cpu", "throughput_indp_cpu", "mean_time_on_file_indp_cpu", "mean_time_cpu_on_page_indp_cpu"
+    ]
 
     df = pd.DataFrame(columns=header)
     for directory, name, parameters, page_func in tasks:

--- a/scripts/benchmark_table/metric.py
+++ b/scripts/benchmark_table/metric.py
@@ -11,7 +11,7 @@
 # Source: https://github.com/ibm-aur-nlp/PubTabNet
 
 from collections import deque
-from typing import Optional
+from typing import Iterable, Optional
 
 import distance
 from apted import APTED, Config
@@ -21,7 +21,7 @@ from tqdm import tqdm
 
 
 class TableTree(Tree):
-    def __init__(self, tag: str, colspan=None, rowspan=None, content=None, visible=None, *children):  # noqa
+    def __init__(self, tag: str, colspan: int = None, rowspan: int = None, content: Iterable[str] = None, visible: bool = None, *children: "TableTree") -> None:
         self.tag = tag
         self.colspan = colspan
         self.rowspan = rowspan
@@ -44,13 +44,13 @@ class TableTree(Tree):
 
 class CustomConfig(Config):
     @staticmethod
-    def maximum(*sequences):  # noqa
+    def maximum(*sequences: str) -> int:
         """
         Get maximum possible value
         """
         return max(map(len, sequences))
 
-    def normalized_distance(self, *sequences) -> float:  # noqa
+    def normalized_distance(self, *sequences: str) -> float:
         """
         Get distance from 0 to 1
         """

--- a/scripts/benchmark_table/metric.py
+++ b/scripts/benchmark_table/metric.py
@@ -21,7 +21,8 @@ from tqdm import tqdm
 
 
 class TableTree(Tree):
-    def __init__(self, tag: str, colspan: int = None, rowspan: int = None, content: Iterable[str] = None, visible: bool = None, *children: "TableTree") -> None:
+    def __init__(self, tag: str, colspan: Optional[int], rowspan: Optional[int], content: Optional[str], visible: Optional[bool], *children: "TableTree") \
+            -> None:
         self.tag = tag
         self.colspan = colspan
         self.rowspan = rowspan
@@ -44,13 +45,13 @@ class TableTree(Tree):
 
 class CustomConfig(Config):
     @staticmethod
-    def maximum(*sequences: str) -> int:
+    def maximum(*sequences: Iterable[str]) -> int:
         """
         Get maximum possible value
         """
         return max(map(len, sequences))
 
-    def normalized_distance(self, *sequences: str) -> float:
+    def normalized_distance(self, *sequences: Iterable[str]) -> float:
         """
         Get distance from 0 to 1
         """

--- a/scripts/create_txtlayer_dataset.py
+++ b/scripts/create_txtlayer_dataset.py
@@ -46,7 +46,7 @@ class CorrectTextGenerator:
                 article_text_fixed = re.sub(self.meta, "", article_text_fixed)
                 article_text_fixed = re.sub(self.symbols, "", article_text_fixed)
                 article_text_fixed = re.sub(r"\n+", "\n", article_text_fixed)
-            except:  # noqa
+            except Exception:
                 article_text_fixed = ""
 
         return article_text_fixed

--- a/scripts/train/train_acc_orientation_classifier.py
+++ b/scripts/train/train_acc_orientation_classifier.py
@@ -90,7 +90,7 @@ def calc_accuracy_by_classes(testloader: DataLoader, classes: List, classifier: 
                 class_correct[columns_i] += orientation_bool_predict
                 class_total[columns_i] += 1
                 if not orientation_bool_predict or not columns_bool_predict:
-                    print( # noqa
+                    print(
                         f'{data["image_name"][i]} predict as \norientation: {classes[2 + orientation_predicted[i]]} \ncolumns: {classes[columns_predicted[i]]}'
                     )
 

--- a/scripts/train/trainers/base_sklearn_line_classifier.py
+++ b/scripts/train/trainers/base_sklearn_line_classifier.py
@@ -7,7 +7,7 @@ import os
 import pickle
 from collections import Counter, OrderedDict
 from statistics import mean
-from typing import Any, Callable, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import numpy as np
 from sklearn.metrics import accuracy_score
@@ -28,7 +28,7 @@ class BaseClassifier(XGBClassifier):
     Base class for a classifier.
     See documentation of `XGBClassifier <https://xgboost.readthedocs.io/en/stable/python/python_api.html#xgboost.XGBClassifier>`_ to get more details.
     """
-    def __init__(self, **kwargs: Any) -> None:  # noqa
+    def __init__(self, **kwargs: Dict) -> None:
         super().__init__(**kwargs)
 
 

--- a/scripts/train/trainers/base_sklearn_line_classifier.py
+++ b/scripts/train/trainers/base_sklearn_line_classifier.py
@@ -7,7 +7,7 @@ import os
 import pickle
 from collections import Counter, OrderedDict
 from statistics import mean
-from typing import Callable, Dict, List, Optional
+from typing import Callable, List, Optional
 
 import numpy as np
 from sklearn.metrics import accuracy_score
@@ -28,7 +28,7 @@ class BaseClassifier(XGBClassifier):
     Base class for a classifier.
     See documentation of `XGBClassifier <https://xgboost.readthedocs.io/en/stable/python/python_api.html#xgboost.XGBClassifier>`_ to get more details.
     """
-    def __init__(self, **kwargs: Dict) -> None:
+    def __init__(self, **kwargs: dict) -> None:
         super().__init__(**kwargs)
 
 

--- a/tests/unit_tests/test_misc_line_object_linker.py
+++ b/tests/unit_tests/test_misc_line_object_linker.py
@@ -27,7 +27,7 @@ class TestLineObjectLinker(unittest.TestCase):
         line4 = create_line_by_coordinates(x_top_left=15, y_top_left=7, height=2, width=7, page=0)
         line5 = create_line_by_coordinates(x_top_left=2, y_top_left=1, height=2, width=9, page=1)
         lines = [line1, line2, line3, line4, line5]
-        self.metadata_extractor._LineMetadataExtractor__add_spacing_annotations(lines)  # noqa
+        self.metadata_extractor._LineMetadataExtractor__add_spacing_annotations(lines)
         self.assertEqual(self.metadata_extractor.default_spacing, self._get_spacing(line1))
         self.assertEqual(50, self._get_spacing(line2))
         self.assertEqual(self.metadata_extractor.default_spacing, self._get_spacing(line3))


### PR DESCRIPTION
Удалил noqa везде, где смог: 
- в случае недобавленных импортов; 
- в тех местах, где удаление не приводило к возникновению жалоб флэйка; 
- в случаях, где смог понять по коду, на что заменить Any в аннотации функций;
- в эксэспшнах, заменив `except:` на `except Exception`. Решил, что добавлять при этом логи не стоит, т.к. раньше их не было. Если надо добавить, могу это сделать;
- в случаях, где смог правильно перенести часть выражения на следующую строку

Решил не удалять noqa в случаях, где:
- по коду непонятно, на что заменить Any
- в бенчмарках используется `print()`
- в случае длинного названия файла, которое нельзя нормально перенести на следующую строку
- название аттрибута совпадает со встроенным в питон

Не смог пофиксить circular imports, из-за которых возникали ошибки в следующих файлах:
`./dedoc/readers/pdf_reader/pdf_image_reader/ocr/ocr_cell_extractor.py`
`./dedoc/readers/docx_reader/data_structures/run.py`