### PR TITLE
Replacing subprocess.run with subprocess.Popen for the prevention of zombie processes

### DIFF
--- a/dedoc/converters/concrete_converters/abstract_converter.py
+++ b/dedoc/converters/concrete_converters/abstract_converter.py
@@ -60,19 +60,30 @@ class AbstractConverter(ABC):
     def _run_subprocess(self, command: List[str], filename: str, expected_path: str) -> None:
         import os
         import subprocess
-
+    
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         try:
-            conversion_results = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=self.timeout)
-            error_message = conversion_results.stderr.decode().strip()
-            if len(error_message) > 0:
+            stdout, stderr = process.communicate(timeout=self.timeout)
+            error_message = stderr.decode().strip()
+    
+            if error_message:
                 if os.path.isfile(expected_path):
                     self.logger.warning(f"Warning on file {filename}\n{error_message}")
                 else:
                     error_message = f"Could not convert file {filename}\n{error_message}"
                     self.logger.error(error_message)
                     raise ConversionError(msg=error_message)
-
+    
         except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
             message = f"Conversion of the {filename} hadn't terminated after {self.timeout} seconds"
             self.logger.error(message)
             raise ConversionError(msg=message)
+        except Exception as e:
+            self.logger.error(f"An error occurred: {str(e)}")
+            raise
+        finally:
+            if process.poll() is None:
+                process.terminate()
+            process.wait()

--- a/dedoc/converters/concrete_converters/abstract_converter.py
+++ b/dedoc/converters/concrete_converters/abstract_converter.py
@@ -60,7 +60,7 @@ class AbstractConverter(ABC):
     def _run_subprocess(self, command: List[str], filename: str, expected_path: str) -> None:
         import os
         import subprocess
-    
+
         process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         try:
             stdout, stderr = process.communicate(timeout=self.timeout)
@@ -73,7 +73,6 @@ class AbstractConverter(ABC):
                     error_message = f"Could not convert file {filename}\n{error_message}"
                     self.logger.error(error_message)
                     raise ConversionError(msg=error_message)
-    
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait()

--- a/dedoc/readers/pdf_reader/pdf_txtlayer_reader/tabbypdf/tabbypdf.py
+++ b/dedoc/readers/pdf_reader/pdf_txtlayer_reader/tabbypdf/tabbypdf.py
@@ -19,17 +19,18 @@ def _jar_path() -> str:
 
 def _run(path: str = None, encoding: str = "utf-8") -> bytes:
     args = ["java"] + ["-jar", _jar_path(), "-i", path]
-
+    process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.DEVNULL)
     try:
-        result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.DEVNULL, check=True)
-        if result.stderr:
-            logger.warning(f"Got stderr: {result.stderr.decode(encoding)}")
-        return result.stdout
+        stdout, stderr = process.communicate()
+        if stderr:
+            logger.warning(f"Got stderr: {stderr.decode(encoding)}")
+        return stdout
     except FileNotFoundError:
         raise JavaNotFoundError(JAVA_NOT_FOUND_ERROR)
-    except subprocess.CalledProcessError as e:
-        logger.error(f"Error from tabby-java:\n{e.stderr.decode(encoding)}\n")
-        raise
+    finally:
+        if process.poll() is None:
+            process.terminate()
+        process.wait()
 
 
 def extract(path: str) -> dict:


### PR DESCRIPTION
Dedoc periodically stops working - it does not respond, although the processes do not terminate. I can see the presence of zombie processes in the console. I don't know what it's related to. But it is recommended to use Popen as a safer operation to prevent z-processes.
